### PR TITLE
Feedback on new support for more than one look-ahead tokens

### DIFF
--- a/src/Parser.cs
+++ b/src/Parser.cs
@@ -361,23 +361,7 @@ namespace Gratt
                     return (kind2, token2);
                 }
                 default:
-                {
-                    var stack = new Stack<(TKind, TToken)>(offset + 1);
-                    while (true)
-                    {
-                        var read = Read();
-                        stack.Push(read);
-                        if (offset-- == 0)
-                        {
-                            while (stack.Count > 0)
-                            {
-                                var (kind, token) = stack.Pop();
-                                Unread(kind, token);
-                            }
-                            return read;
-                        }
-                    }
-                }
+                    throw new InvalidOperationException();
             }
         }
 

--- a/tests/ParserTests.cs
+++ b/tests/ParserTests.cs
@@ -6,6 +6,7 @@ namespace Gratt.Tests
     {
         enum TokenKind
         {
+            Qux,
             Foo,
             Bar,
             Baz,
@@ -30,11 +31,24 @@ namespace Gratt.Tests
             Assert.That(result, Is.EqualTo("foobarbaz"));
         }
 
+        [Test]
+        public void ReadAheadMore()
+        {
+            Assert.Throws<System.InvalidOperationException>(() =>
+                Parse((TokenKind.Qux, "qux"), (TokenKind.Foo, "foo"),
+                      (TokenKind.Bar, "bar"), (TokenKind.Baz, "baz"),
+                      (TokenKind.Eoi, string.Empty))
+                );
+        }
+
         static string Parse(params (TokenKind Kind, string Token)[] tokens) =>
             Parser.Parse<TokenKind, string, int, string>(0, TokenKind.Eoi, _ => new(),
                                                          (_, _) =>
                                                              (token, parser)
-                                                                 => parser.Peek() is (TokenKind.Bar, _)
+                                                                 => parser.Peek() is (TokenKind.Foo, _)
+                                                                    && parser.Peek(1) is (TokenKind.Bar, _)
+                                                                    && parser.Peek(2) is (TokenKind.Baz, _) ? "quxfoobarbaz"
+                                                                  : parser.Peek() is (TokenKind.Bar, _)
                                                                     && parser.Peek(1) is (TokenKind.Baz, _)
                                                                     && parser.Match(TokenKind.Bar)
                                                                     && parser.Match(TokenKind.Baz) ? "foobarbaz"


### PR DESCRIPTION
@atifaziz here is a quick PR on top of your `multi-peek` branch.

My question is what is the purpose of the `default` case in the `Peek()` method ?
It seems to me that support for more than two look-ahead tokens is guaranteed to throw an exception.

I added a simple test illustrate this.

I like the `ITokenStream` abstraction that as been introduced.

As a general question why limit the implementation to only two tokens?
I guess there should not be a grammar that needs more than two tokens of lookahead.

Also, it seems that maybe the design you chose is extensible to more than two tokens of lookahead in the future, maybe by introducing a future `ThreeTokenStackOps`, etc. But what lead you to this design, with two different `StoreStackOps` implementations? Is this for performance reason ? Is this in an attempt to prevent more upfront allocations for multiple tokens if not eventually necessary?